### PR TITLE
feat: add metrics for number of deleted topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,6 @@ The defaults should normally be sufficient, but if required please consult the
 [Spring Boot common application properties](https://docs.spring.io/spring-boot/appendix/application-properties/index.html)
 for reference.
 
-The application provides a
-[Prometheus endpoint](https://docs.spring.io/spring-boot/reference/actuator/metrics.html#actuator.metrics.export.prometheus)
-with all application metrics enabled by default.
-
 Configuration using environment variables is recommended.
 Please see
 [Spring Boot externalized configuration](https://docs.spring.io/spring-boot/reference/features/external-config.html)
@@ -71,3 +67,18 @@ See
 for an overview and
 [application.yaml](src/main/resources/application.yaml)
 for the current default values.
+
+## Observability
+
+The application provides a
+[Prometheus endpoint](https://docs.spring.io/spring-boot/reference/actuator/metrics.html#actuator.metrics.export.prometheus)
+with all application metrics enabled by default.
+
+In addition to the standard JVM and Spring Boot metrics, the application
+provides some application specific metrics:
+
+```
+# HELP topic_deleted_total Number of topics deleted
+# TYPE topic_deleted_total counter
+topic_deleted_total N.0
+```

--- a/src/main/java/io/statnett/k3a/topicterminator/ApplicationConfiguration.java
+++ b/src/main/java/io/statnett/k3a/topicterminator/ApplicationConfiguration.java
@@ -1,5 +1,6 @@
 package io.statnett.k3a.topicterminator;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
@@ -10,7 +11,7 @@ import org.springframework.kafka.core.KafkaAdmin;
 public class ApplicationConfiguration {
 
     @Bean
-    public TopicTerminator topicTerminator(ApplicationProperties props, KafkaAdmin kafkaAdmin) {
-        return new TopicTerminator(props, kafkaAdmin);
+    public TopicTerminator topicTerminator(ApplicationProperties props, KafkaAdmin kafkaAdmin, MeterRegistry meterRegistry) {
+        return new TopicTerminator(props, kafkaAdmin, meterRegistry);
     }
 }


### PR DESCRIPTION
I don't want to browse through logs to see what this app is doing (or not doing). For more observability, I want to add a counter metric to see how many topics are deleted.