### PR TITLE
feat: ability to bless (not terminate) topics by name/regex

### DIFF
--- a/src/main/java/io/statnett/k3a/topicterminator/ApplicationProperties.java
+++ b/src/main/java/io/statnett/k3a/topicterminator/ApplicationProperties.java
@@ -28,7 +28,7 @@ public class ApplicationProperties {
     private boolean dryRun;
 
     /**
-     * Used to specify topics that should retain in the cluster,
+     * Used to specify topics that should be retained in the cluster,
      * even if the topic is marked for termination by the other rules.
      * Can be specified as a list or a comma separated value of topic
      * name regular expressions.

--- a/src/main/java/io/statnett/k3a/topicterminator/ApplicationProperties.java
+++ b/src/main/java/io/statnett/k3a/topicterminator/ApplicationProperties.java
@@ -4,6 +4,9 @@ import jakarta.validation.constraints.NotEmpty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
+import java.util.Collection;
+import java.util.regex.Pattern;
+
 @ConfigurationProperties("app")
 @Validated
 public class ApplicationProperties {
@@ -24,6 +27,14 @@ public class ApplicationProperties {
      */
     private boolean dryRun;
 
+    /**
+     * Used to specify topics that should retain in the cluster,
+     * even if the topic is marked for termination by the other rules.
+     * Can be specified as a list or a comma separated value of topic
+     * name regular expressions.
+     */
+    private Collection<Pattern> blessedTopics;
+
     public String getFixedRateString() {
         return fixedRateString;
     }
@@ -38,5 +49,13 @@ public class ApplicationProperties {
 
     public void setDryRun(boolean dryRun) {
         this.dryRun = dryRun;
+    }
+
+    public Collection<Pattern> getBlessedTopics() {
+        return blessedTopics;
+    }
+
+    public void setBlessedTopics(Collection<Pattern> blessedTopics) {
+        this.blessedTopics = blessedTopics;
     }
 }

--- a/src/main/java/io/statnett/k3a/topicterminator/TopicTerminator.java
+++ b/src/main/java/io/statnett/k3a/topicterminator/TopicTerminator.java
@@ -2,6 +2,7 @@ package io.statnett.k3a.topicterminator;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.statnett.k3a.topicterminator.strategy.BlessedTopic;
 import io.statnett.k3a.topicterminator.strategy.ConsumedTopic;
 import io.statnett.k3a.topicterminator.strategy.InternalTopic;
 import io.statnett.k3a.topicterminator.strategy.NonEmptyTopic;
@@ -49,7 +50,8 @@ public class TopicTerminator {
             Collection<ReservedTopic> reservedTopics = List.of(
                 new ConsumedTopic(),
                 new InternalTopic(allTopics),
-                new NonEmptyTopic()
+                new NonEmptyTopic(),
+                new BlessedTopic(allTopics, props.getBlessedTopics())
             );
 
             for (ReservedTopic reservedTopic : reservedTopics) {

--- a/src/main/java/io/statnett/k3a/topicterminator/strategy/BlessedTopic.java
+++ b/src/main/java/io/statnett/k3a/topicterminator/strategy/BlessedTopic.java
@@ -1,0 +1,34 @@
+package io.statnett.k3a.topicterminator.strategy;
+
+import org.apache.kafka.clients.admin.AdminClient;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class BlessedTopic implements ReservedTopic {
+    private final Set<String> allNames;
+    private final Collection<Pattern> patterns;
+
+    public BlessedTopic(Set<String> allNames, Collection<Pattern> patterns) {
+        this.allNames = allNames;
+        this.patterns = patterns;
+    }
+
+    @Override
+    public Set<String> getNames(AdminClient client) {
+        if (patterns == null || patterns.isEmpty()) {
+            return Collections.emptySet();
+        }
+        return allNames.stream()
+            .filter(this::isBlessed)
+            .collect(Collectors.toSet());
+    }
+
+    private boolean isBlessed(String topicName) {
+        return patterns.stream()
+            .anyMatch(pattern -> pattern.matcher(topicName).matches());
+    }
+}

--- a/src/test/java/io/statnett/k3a/topicterminator/ApplicationTest.java
+++ b/src/test/java/io/statnett/k3a/topicterminator/ApplicationTest.java
@@ -35,6 +35,8 @@ public class ApplicationTest {
     public static final String TOPIC_INTERNAL = "_schemas";
     public static final String TOPIC_UNUSED = "topic-unused";
     public static final String TOPIC_WITH_DATA = "topic-with-data";
+    public static final String TOPIC_BLESSED_BY_REGEX = "blessed-topic";
+    public static final String TOPIC_BLESSED_BY_NAME = "topic-foo";
 
     @Autowired
     private KafkaTemplate<String, String> kafkaTemplate;
@@ -66,7 +68,7 @@ public class ApplicationTest {
             Set<String> allTopics = client.listTopics(new ListTopicsOptions().listInternal(true)).names().get();
 
             assertThat(allTopics)
-                .contains(TOPIC_CONSUMED, TOPIC_INTERNAL, TOPIC_WITH_DATA)
+                .contains(TOPIC_CONSUMED, TOPIC_INTERNAL, TOPIC_WITH_DATA, TOPIC_BLESSED_BY_REGEX, TOPIC_BLESSED_BY_NAME)
                 .doesNotContain(TOPIC_UNUSED);
         }
 
@@ -104,6 +106,18 @@ public class ApplicationTest {
         @Bean
         public NewTopic topicWithData() {
             return TopicBuilder.name(TOPIC_WITH_DATA)
+                .build();
+        }
+
+        @Bean
+        public NewTopic topicBlessedByRegex() {
+            return TopicBuilder.name(TOPIC_BLESSED_BY_REGEX)
+                .build();
+        }
+
+        @Bean
+        public NewTopic topicBlessedByName() {
+            return TopicBuilder.name(TOPIC_BLESSED_BY_NAME)
                 .build();
         }
     }

--- a/src/test/resources/config/application.yaml
+++ b/src/test/resources/config/application.yaml
@@ -1,2 +1,3 @@
 app:
   dry-run: false
+  blessed-topics: ^blessed.*,topic-foo


### PR DESCRIPTION
We have some topics in our cluster without data or consumers that is somehow still in use. This new feature will allow us to configure those topics to retain - even if they are marked for deletion by the standard rules.