### PR TITLE
feat: add opt-in to terminate non-empty topics matching props

### DIFF
--- a/src/main/java/io/statnett/k3a/topicterminator/ApplicationProperties.java
+++ b/src/main/java/io/statnett/k3a/topicterminator/ApplicationProperties.java
@@ -5,6 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 @ConfigurationProperties("app")
@@ -35,6 +36,14 @@ public class ApplicationProperties {
      */
     private Collection<Pattern> blessedTopics;
 
+    /**
+     * Can be used to terminate topics even if the topic contains data
+     * (destructive operation) if the topic is otherwise considered unused.
+     * The supplied properties will be matched against topic configuration,
+     * and all properties must match!
+     */
+    private Map<String, String> nonEmptyTopicsMatchingProps;
+
     public String getFixedRateString() {
         return fixedRateString;
     }
@@ -57,5 +66,13 @@ public class ApplicationProperties {
 
     public void setBlessedTopics(Collection<Pattern> blessedTopics) {
         this.blessedTopics = blessedTopics;
+    }
+
+    public Map<String, String> getNonEmptyTopicsMatchingProps() {
+        return nonEmptyTopicsMatchingProps;
+    }
+
+    public void setNonEmptyTopicsMatchingProps(Map<String, String> nonEmptyTopicsMatchingProps) {
+        this.nonEmptyTopicsMatchingProps = nonEmptyTopicsMatchingProps;
     }
 }

--- a/src/main/java/io/statnett/k3a/topicterminator/strategy/AndOperation.java
+++ b/src/main/java/io/statnett/k3a/topicterminator/strategy/AndOperation.java
@@ -1,0 +1,31 @@
+package io.statnett.k3a.topicterminator.strategy;
+
+import org.apache.kafka.clients.admin.AdminClient;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+
+public class AndOperation implements ReservedTopic {
+
+    private final ReservedTopic[] parts;
+
+    public AndOperation(ReservedTopic... parts) {
+        this.parts = parts;
+    }
+
+    @Override
+    public Set<String> filter(AdminClient client, Set<String> topicNames) throws ExecutionException, InterruptedException {
+        if (parts.length == 0) {
+            return topicNames;
+        }
+
+        HashSet<String> reserved = new HashSet<>();
+        for (ReservedTopic reservedTopic : parts) {
+            reserved.addAll(reservedTopic.filter(client, new HashSet<>(topicNames)));
+        }
+        topicNames.retainAll(reserved);
+        return topicNames;
+    }
+}

--- a/src/main/java/io/statnett/k3a/topicterminator/strategy/ReservedIfTopicNotMatchingProps.java
+++ b/src/main/java/io/statnett/k3a/topicterminator/strategy/ReservedIfTopicNotMatchingProps.java
@@ -1,0 +1,50 @@
+package io.statnett.k3a.topicterminator.strategy;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.common.config.ConfigResource;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.emptySet;
+import static java.util.Collections.unmodifiableSet;
+
+public class ReservedIfTopicNotMatchingProps implements ReservedTopic {
+    private final Set<Map.Entry<String, String>> matchingProps;
+
+    public ReservedIfTopicNotMatchingProps(Map<String, String> matchingProps) {
+        if (matchingProps == null) {
+            this.matchingProps = emptySet();
+        } else {
+            this.matchingProps = unmodifiableSet(matchingProps.entrySet());
+        }
+    }
+
+    @Override
+    public Set<String> filter(AdminClient client, Set<String> topicNames) throws ExecutionException, InterruptedException {
+        if (matchingProps.isEmpty()) {
+            return emptySet();
+        }
+
+        List<ConfigResource> topicResources = topicNames.stream()
+            .map(t -> new ConfigResource(ConfigResource.Type.TOPIC, t))
+            .toList();
+
+        Map<String, Map<String, String>> topicProps = client.describeConfigs(topicResources).all().get().entrySet().stream()
+            .collect(Collectors.toMap(
+                    entry -> entry.getKey().name(),
+                    entry -> entry.getValue().entries().stream().collect(
+                        Collectors.toMap(ConfigEntry::name, ConfigEntry::value)
+                    )
+                )
+            );
+
+        return topicNames.stream()
+            .filter(t -> topicProps.get(t).entrySet().containsAll(matchingProps))
+            .collect(Collectors.toSet());
+    }
+}

--- a/src/test/resources/config/application.yaml
+++ b/src/test/resources/config/application.yaml
@@ -1,3 +1,5 @@
 app:
   dry-run: false
   blessed-topics: ^blessed.*,topic-foo
+  non-empty-topics-matching-props:
+    cleanup.policy: compact


### PR DESCRIPTION
We want to terminate non-empty compacting, otherwise unused topics in our clusters. The PR adds an option to delete topics with data if the topic configuration matches the supplied properties.