### PR TITLE
fix: initialize NonEmptyTopicCharacteristics to avoid NPE

### DIFF
--- a/src/main/java/io/statnett/k3a/topicterminator/ApplicationProperties.java
+++ b/src/main/java/io/statnett/k3a/topicterminator/ApplicationProperties.java
@@ -40,7 +40,7 @@ public class ApplicationProperties {
      * (destructive operation) if the topic is otherwise considered unused.
      * By default, no topics with data will be deleted.
      */
-    private NonEmptyTopicCharacteristics nonEmptyTopics;
+    private NonEmptyTopicCharacteristics nonEmptyTopics = new NonEmptyTopicCharacteristics();
 
     public String getFixedRateString() {
         return fixedRateString;


### PR DESCRIPTION
I noticed this in our logs, and I think the problem is that we are not enabling the terminate non-empty topic feature:

````json
{"@timestamp":"2025-01-28T16:54:53.166610422Z","@version":"1","message":"Terminating unused topics","logger_name":"io.statnett.k3a.topicterminator.TopicTerminator","thread_name":"scheduling-2","level":"INFO","level_value":20000,"dry-run":true}
{"@timestamp":"2025-01-28T16:54:53.171310524Z","@version":"1","message":"Unexpected error occurred in scheduled task","logger_name":"org.springframework.scheduling.support.TaskUtils$LoggingErrorHandler","thread_name":"scheduling-2","level":"ERROR","level_value":40000,"stack_trace":"java.lang.NullPointerException: Cannot invoke \"io.statnett.k3a.topicterminator.ApplicationProperties$NonEmptyTopicCharacteristics.isWithoutTimeRetention()\" because the return value of \"io.statnett.k3a.topicterminator.ApplicationProperties.getNonEmptyTopics()\" is null\n\tat io.statnett.k3a.topicterminator.TopicTerminator.terminateUnusedTopics(TopicTerminator.java:54)\n\tat java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)\n\tat java.base/java.lang.reflect.Method.invoke(Unknown Source)\n\tat org.springframework.scheduling.support.ScheduledMethodRunnable.runInternal(ScheduledMethodRunnable.java:130)\n\tat org.springframework.scheduling.support.ScheduledMethodRunnable.lambda$run$2(ScheduledMethodRu...
````